### PR TITLE
:sparkles: Add support for next.jdbc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.0
+
+* This version was forked from [ragtime-clj](https://github.com/mariusz-jachimowicz-83/ragtime-clj).
+* Support next.jdbc by updating ragtime to 0.9.2. This also updates the minimum required Clojure version to 1.10.3.
+
 ## 0.1.1
 
 * Improve regexp to handle file to namespace name conversion (thx [Rune Juhl Jacobsen](https://github.com/runejuhl))

--- a/deps.edn
+++ b/deps.edn
@@ -5,5 +5,5 @@
    :extra-paths ["test"]}}
  :deps
  {dev.weavejester/ragtime {:mvn/version "0.9.0"}
-  org.clojure/clojure     {:mvn/version "1.9.0-beta4"}}
+  org.clojure/clojure     {:mvn/version "1.10.3"}}
  :paths ["src"]}

--- a/deps.edn
+++ b/deps.edn
@@ -5,5 +5,5 @@
    :extra-paths ["test"]}}
  :deps
  {org.clojure/clojure {:mvn/version "1.9.0-beta4"}
-  ragtime/ragtime     {:mvn/version "0.8.0"}}
+  ragtime/ragtime     {:mvn/version "0.8.1"}}
  :paths ["src"]}

--- a/deps.edn
+++ b/deps.edn
@@ -5,5 +5,5 @@
    :extra-paths ["test"]}}
  :deps
  {org.clojure/clojure {:mvn/version "1.9.0-beta4"}
-  ragtime/ragtime     {:mvn/version "0.7.2"}}
+  ragtime/ragtime     {:mvn/version "0.8.0"}}
  :paths ["src"]}

--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,6 @@
                  org.clojure/java.jdbc {:mvn/version "0.5.8"}}
    :extra-paths ["test"]}}
  :deps
- {dev.weavejester/ragtime {:mvn/version "0.9.0"}
+ {dev.weavejester/ragtime {:mvn/version "0.9.1"}
   org.clojure/clojure     {:mvn/version "1.10.3"}}
  :paths ["src"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:aliases
- {:test
+ {:dev
   {:extra-deps  {com.h2database/h2     {:mvn/version "1.3.160"}
                  org.clojure/java.jdbc {:mvn/version "0.5.8"}}
    :extra-paths ["test"]}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,6 @@
                  org.clojure/java.jdbc {:mvn/version "0.5.8"}}
    :extra-paths ["test"]}}
  :deps
- {org.clojure/clojure {:mvn/version "1.9.0-beta4"}
-  ragtime/ragtime     {:mvn/version "0.8.1"}}
+ {dev.weavejester/ragtime {:mvn/version "0.9.0"}
+  org.clojure/clojure     {:mvn/version "1.9.0-beta4"}}
  :paths ["src"]}

--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,6 @@
                  org.clojure/java.jdbc {:mvn/version "0.5.8"}}
    :extra-paths ["test"]}}
  :deps
- {dev.weavejester/ragtime {:mvn/version "0.9.1"}
+ {dev.weavejester/ragtime {:mvn/version "0.9.2"}
   org.clojure/clojure     {:mvn/version "1.10.3"}}
  :paths ["src"]}

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license     {:name "Eclipse Public License"
                 :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[dev.weavejester/ragtime "0.9.0"]
+  :dependencies [[dev.weavejester/ragtime "0.9.1"]
                  [org.clojure/clojure "1.10.3"]]
 
   :deploy-repositories [["clojars" {:sign-releases false}]]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                 :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure   "1.9.0-beta4"]
-                 [ragtime               "0.8.0"]]
+                 [ragtime               "0.8.1"]]
 
   :deploy-repositories [["clojars" {:sign-releases false}]]
 

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license     {:name "Eclipse Public License"
                 :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure   "1.9.0-beta4"]
-                 [ragtime               "0.8.1"]]
+  :dependencies [[dev.weavejester/ragtime "0.9.0"]
+                 [org.clojure/clojure     "1.9.0-beta4"]]
 
   :deploy-repositories [["clojars" {:sign-releases false}]]
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license     {:name "Eclipse Public License"
                 :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[dev.weavejester/ragtime "0.9.1"]
+  :dependencies [[dev.weavejester/ragtime "0.9.2"]
                  [org.clojure/clojure "1.10.3"]]
 
   :deploy-repositories [["clojars" {:sign-releases false}]]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                 :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[dev.weavejester/ragtime "0.9.0"]
-                 [org.clojure/clojure     "1.9.0-beta4"]]
+                 [org.clojure/clojure "1.10.3"]]
 
   :deploy-repositories [["clojars" {:sign-releases false}]]
 

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                 :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure   "1.9.0-beta4"]
-                 [ragtime               "0.7.2"]]
+                 [ragtime               "0.8.0"]]
 
   :deploy-repositories [["clojars" {:sign-releases false}]]
 

--- a/src/ragtime/clj/core.clj
+++ b/src/ragtime/clj/core.clj
@@ -20,9 +20,6 @@
   [migration-map]
   (map->CljMigration migration-map))
 
-(defn- file-extension [file]
-  (re-find #"\.[^.]*$" (str file)))
-
 (let [pattern (re-pattern (str "([^\\" File/separator "]*)\\" File/separator "?$"))]
   (defn- basename [file]
     (second (re-find pattern (str file)))))

--- a/src/ragtime/clj/core.clj
+++ b/src/ragtime/clj/core.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [load-file])
   (:require
     [ragtime.jdbc]
+    [ragtime.next-jdbc]
     [ragtime.protocols])
   (:import [java.io File]))
 
@@ -40,7 +41,7 @@
                                  (name namespace-symbol)
                                  (name fn-symbol))))))
 
-(defmethod ragtime.jdbc/load-files ".clj" [files]
+(defn- load-clj-migration-files [files]
   (for [file files]
     (let [ns-sym  (-> file slurp clj-file->ns-name symbol)
           _       (require ns-sym)
@@ -50,3 +51,9 @@
       (clj-migration {:id   id
                       :up   up-fn
                       :down down-fn}))))
+
+(defmethod ragtime.jdbc/load-files ".clj" [files]
+  (load-clj-migration-files files))
+
+(defmethod ragtime.next-jdbc/load-files ".clj" [files]
+  (load-clj-migration-files files))

--- a/src/ragtime/clj/core.clj
+++ b/src/ragtime/clj/core.clj
@@ -1,7 +1,6 @@
 (ns ragtime.clj.core
   (:refer-clojure :exclude [load-file])
   (:require
-    [clojure.java.jdbc :as jdbc]
     [ragtime.jdbc]
     [ragtime.protocols])
   (:import [java.io File]))

--- a/test/ragtime/clj/core_test.clj
+++ b/test/ragtime/clj/core_test.clj
@@ -5,7 +5,7 @@
             [ragtime.next-jdbc :as ragtime-next-jdbc]
             [ragtime.protocols :as ragtime-protocols]
             [clojure.java.jdbc :as jdbc]
-            [ragtime.clj.core :refer [clj-file->ns-name]]))
+            [ragtime.clj.core  :refer [clj-file->ns-name]]))
 
 (def db-spec "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1")
 

--- a/test/ragtime/clj/core_test.clj
+++ b/test/ragtime/clj/core_test.clj
@@ -1,5 +1,5 @@
 (ns ragtime.clj.core-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test      :refer [deftest is use-fixtures]]
             [ragtime.jdbc      :as ragtime-jdbc]
             [ragtime.core      :as ragtime]
             [ragtime.next-jdbc :as ragtime-next-jdbc]

--- a/test/ragtime/clj/core_test.clj
+++ b/test/ragtime/clj/core_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [ragtime.jdbc      :as ragtime-jdbc]
             [ragtime.core      :as ragtime]
+            [ragtime.next-jdbc :as ragtime-next-jdbc]
             [ragtime.protocols :as ragtime-protocols]
             [clojure.java.jdbc :as jdbc]
             [ragtime.clj.core :refer [clj-file->ns-name]]))
@@ -16,30 +17,36 @@
   (set (jdbc/query (:db-spec db) ["SHOW TABLES"] {:row-fn :table_name})))
 
 (deftest test-load-directory
-  (let [db  (ragtime-jdbc/sql-database db-spec)
-        ms  (ragtime-jdbc/load-directory "test/migrations")
-        idx (ragtime/into-index ms)]
-    (ragtime/migrate-all db idx ms)
-    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "CLJT_1" "CLJT_2"}
-           (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007_test" "008_test"]
-           (ragtime-protocols/applied-migration-ids db)))
-    (ragtime/rollback-last db idx (count ms))
-    (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
-    (is (empty? (ragtime-protocols/applied-migration-ids db)))))
+  (for [{:keys [db]
+         ms    :migrations} [{:db         (ragtime-jdbc/sql-database db-spec)
+                              :migrations (ragtime-jdbc/load-directory "test/migrations")}
+                             {:db         (ragtime-next-jdbc/sql-database db-spec)
+                              :migrations (ragtime-next-jdbc/load-directory "test/migrations")}]]
+    (let [idx (ragtime/into-index ms)]
+      (ragtime/migrate-all db idx ms)
+      (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "CLJT_1" "CLJT_2"}
+             (table-names db)))
+      (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007_test" "008_test"]
+             (ragtime-protocols/applied-migration-ids db)))
+      (ragtime/rollback-last db idx (count ms))
+      (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
+      (is (empty? (ragtime-protocols/applied-migration-ids db))))))
 
 (deftest test-load-resources
-  (let [db  (ragtime-jdbc/sql-database db-spec)
-        ms  (ragtime-jdbc/load-resources "migrations")
-        idx (ragtime/into-index ms)]
-    (ragtime/migrate-all db idx ms)
-    (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "CLJT_1" "CLJT_2"}
-           (table-names db)))
-    (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007_test" "008_test"]
-           (ragtime-protocols/applied-migration-ids db)))
-    (ragtime/rollback-last db idx (count ms))
-    (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
-    (is (empty? (ragtime-protocols/applied-migration-ids db)))))
+  (for [{:keys [db]
+         ms    :migrations} [{:db         (ragtime-jdbc/sql-database db-spec)
+                              :migrations (ragtime-jdbc/load-directory "test/migrations")}
+                             {:db         (ragtime-next-jdbc/sql-database db-spec)
+                              :migrations (ragtime-next-jdbc/load-directory "test/migrations")}]]
+    (let [idx (ragtime/into-index ms)]
+      (ragtime/migrate-all db idx ms)
+      (is (= #{"RAGTIME_MIGRATIONS" "FOO" "BAR" "BAZ" "QUZA" "QUZB" "QUXA" "QUXB" "LAST_TABLE" "CLJT_1" "CLJT_2"}
+             (table-names db)))
+      (is (= ["001-test" "002-bar" "003-test" "004-test" "005-test" "006-test" "007_test" "008_test"]
+             (ragtime-protocols/applied-migration-ids db)))
+      (ragtime/rollback-last db idx (count ms))
+      (is (= #{"RAGTIME_MIGRATIONS"} (table-names db)))
+      (is (empty? (ragtime-protocols/applied-migration-ids db))))))
 
 (deftest ns-name-regex
   (is (=


### PR DESCRIPTION
# Changes
- :sparkles: Add support for next.jdbc by upgrading ragtime to 0.9.2 and clojure to 1.10.3.
- :white_check_mark: Update unit tests to include ragtime.next-jdbc